### PR TITLE
CI: Introduce new satchecker regression workflow run

### DIFF
--- a/.github/workflows/run-sat-regression.yaml
+++ b/.github/workflows/run-sat-regression.yaml
@@ -1,0 +1,21 @@
+name: Run SAT regression tests
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install dependencies
+      run: yarn install --frozen-lockfile
+    - name: Build
+      run: yarn build
+    - name: Install minisat
+      run: sudo apt-get install -y minisat
+    - name: Run regression test
+      run: yarn test-satchecker

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 		"dimacs": "node --enable-source-maps built/shiru/dimacs.js",
 		"cmd": "node --enable-source-maps built/shiru/cmd.js",
 		"build": "tsc",
-		"pack-amd": "tsc --project tsconfig-amd.json"
+		"pack-amd": "tsc --project tsconfig-amd.json",
+		"test-satchecker": "node --enable-source-maps built/shiru/satchecker/checker.js"
 	},
 	"dependencies": {
 		"@types/node": "^14.6.4"


### PR DESCRIPTION
This PR introduces a new CI step to run 3-sat regression tests against the SAT solver.

This would have caught bugs like those fixed in https://github.com/CurtisFenner/shiru-ts/commit/3d68d40962d6d6a21fdd0d368e881a7d48c1182c.