### PR TITLE
Fix: Fix incorrect 'eq' simplification logic

### DIFF
--- a/.github/workflows/run-sat-regression-tests.yaml
+++ b/.github/workflows/run-sat-regression-tests.yaml
@@ -7,7 +7,7 @@ on:
     branches: ["main"]
 
 jobs:
-  run-tests:
+  run-sat-regression-tests:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/src/shiru/uf.ts
+++ b/src/shiru/uf.ts
@@ -870,17 +870,28 @@ export class UFTheory extends smt.SMTSolver<ValueID[], UFCounterexample> {
 		semantics: Semantics<ReasonSatLiteral>,
 		debugName: string,
 	): FnID {
+		if (semantics.not) {
+			return this.notFn;
+		}
 		return this.solver.createFn(returnType, semantics, debugName);
 	}
 
-	notFn = this.createFunction(ir.T_BOOLEAN, { not: true }, "not");
+	notFn = this.solver.createFn(ir.T_BOOLEAN, {
+		not: true,
+		interpreter(a: unknown) {
+			if (typeof a === "boolean") {
+				return !a;
+			}
+			return null;
+		},
+	}, "not");
 
 	createApplication(fnID: FnID, args: ValueID[]): ValueID {
 		// Apply simplifications
 		const semantics = this.solver.getFnSemantics(fnID);
 		if (semantics.eq === true) {
 			const left = args[0];
-			const right = args[0];
+			const right = args[1];
 			if (left === this.solver.trueObject) {
 				return right;
 			} else if (left === this.solver.falseObject) {

--- a/src/shiru/uf_tests.ts
+++ b/src/shiru/uf_tests.ts
@@ -741,4 +741,56 @@ export const tests = {
 		const response = smt.attemptRefutation();
 		assert(response, "is equal to", { model: {} });
 	},
+	"UFTheory-simplification-regression-test"() {
+		const smt = new uf.UFTheory();
+		const cTrue = smt.createConstant(ir.T_BOOLEAN, true);
+		const cFalse = smt.createConstant(ir.T_BOOLEAN, false);
+		const v = smt.createVariable(ir.T_BOOLEAN, "v");
+		const eq = smt.createFunction(ir.T_BOOLEAN, { eq: true }, "==");
+		const not = smt.createFunction(ir.T_BOOLEAN, { not: true }, "not");
+
+		smt.pushScope();
+		smt.addConstraint([
+			smt.createApplication(eq, [cTrue, v]),
+		]);
+		smt.addConstraint([
+			smt.createApplication(not, [v]),
+		]);
+		const response1 = smt.attemptRefutation();
+		assert(response1, "is equal to", "refuted");
+		smt.popScope();
+
+		smt.pushScope();
+		smt.addConstraint([
+			smt.createApplication(eq, [cFalse, v]),
+		]);
+		smt.addConstraint([
+			v,
+		]);
+		const response2 = smt.attemptRefutation();
+		assert(response2, "is equal to", "refuted");
+		smt.popScope();
+
+		smt.pushScope();
+		smt.addConstraint([
+			smt.createApplication(eq, [v, cTrue]),
+		]);
+		smt.addConstraint([
+			smt.createApplication(not, [v]),
+		]);
+		const response3 = smt.attemptRefutation();
+		assert(response3, "is equal to", "refuted");
+		smt.popScope();
+
+		smt.pushScope();
+		smt.addConstraint([
+			smt.createApplication(eq, [v, cFalse]),
+		]);
+		smt.addConstraint([
+			v,
+		]);
+		const response4 = smt.attemptRefutation();
+		assert(response4, "is equal to", "refuted");
+		smt.popScope();
+	},
 };


### PR DESCRIPTION
This PR fixes a bug in the simplification of function applications with `{ eq; true }` semantics. A typo caused incorrect simplifications such as

| Input | Previous (Incorrect) Behavior | Correct Simplification |
|--|--|--|
| `true == x` | `true` | `x`
| `false == x` | `false` | `not(x)`
| `x == true` | `x == true` | `x`
| `x == false` | `x == false` | `not(x)`