### PR TITLE
Test: Fix missing traces for passing tests

### DIFF
--- a/src/shiru/test.ts
+++ b/src/shiru/test.ts
@@ -58,6 +58,7 @@ export class TestRunner {
 		} catch (e) {
 			const elapsedMillis = performance.now() - beforeMillis;
 			this.runs.push({ name, type: "fail", exception: e, elapsedMillis });
+		} finally {
 			this.traces.push(trace.publish());
 		}
 	}

--- a/src/shiru/trace.ts
+++ b/src/shiru/trace.ts
@@ -197,7 +197,7 @@ pre code {
 
 .numeral {
 	display: inline-block;
-	width: 7em;
+	width: 5.5em;
 	text-align: right;
 	font-weight: bold;
 }


### PR DESCRIPTION
This PR fixes an issue that caused the `trace=` testing command to only generate traces for failing tests.

It also shrinks the size of the runtime on the resulting trace HTMl.