### PR TITLE
Refactor: Remove unnecessary calls to EGraph.getClasses

### DIFF
--- a/src/shiru/builtin.ts
+++ b/src/shiru/builtin.ts
@@ -15,7 +15,7 @@ export const foreignOperations: Record<string, {
 	getInterpreter?(foreignFns: (name: string) => uf.FnID[]): {
 		interpreter?: (...args: (unknown | null)[]) => unknown | null,
 		generalInterpreter?: (
-			matcher: uf.EMatcher<number>,
+			matcher: uf.UFSolver<number>,
 			id: uf.ValueID,
 			operands: uf.ValueID[],
 		) => "change" | "no-change",
@@ -257,7 +257,7 @@ export const foreignOperations: Record<string, {
 				},
 
 				generalInterpreter(
-					matcher: uf.EMatcher<number>,
+					matcher: uf.UFSolver<number>,
 					id: uf.ValueID,
 					operands: uf.ValueID[],
 				): "change" | "no-change" {
@@ -550,7 +550,7 @@ export const foreignOperations: Record<string, {
 				},
 
 				generalInterpreter(
-					matcher: uf.EMatcher<number>,
+					matcher: uf.UFSolver<number>,
 					id: uf.ValueID,
 					operands: uf.ValueID[],
 				): "change" | "no-change" {

--- a/src/shiru/data.ts
+++ b/src/shiru/data.ts
@@ -219,11 +219,26 @@ export class TreeBag<T> {
 	}
 
 	*[Symbol.iterator](): Iterator<T> {
-		yield* this.list;
 		if (this.children !== null) {
-			for (const child of this.children) {
-				yield* child;
+			while (this.children.length > 0) {
+				this.list.push(...this.children.pop()!);
 			}
+			this.children = null;
+		}
+		yield* this.list;
+	}
+}
+
+export function* zipMaps<K, A, B>(
+	left: Map<K, A>,
+	right: Map<K, B>,
+): Generator<[K, A | undefined, B | undefined]> {
+	for (const key of left.keys()) {
+		yield [key, left.get(key), right.get(key)];
+	}
+	for (const key of right.keys()) {
+		if (!left.has(key)) {
+			yield [key, undefined, right.get(key)!];
 		}
 	}
 }

--- a/src/shiru/data.ts
+++ b/src/shiru/data.ts
@@ -190,3 +190,40 @@ export class DisjointSet<E> {
 		return [...components.values()];
 	}
 }
+
+export class TreeBag<T> {
+	readonly size: number;
+	private constructor(private list: T[], private children: TreeBag<T>[] | null) {
+		let childrenSizes = 0;
+		if (children !== null) {
+			for (const child of children) {
+				childrenSizes += child.size;
+			}
+		}
+		this.size = list.length + childrenSizes;
+	}
+
+	static of<T>(...ts: T[]) {
+		return new TreeBag([...ts], null);
+	}
+
+	union(other: TreeBag<T>): TreeBag<T> {
+		if (other.size === 0) {
+			return this;
+		} else if (this.size === 0) {
+			return other;
+		} else if (this.size + other.size < 9) {
+			return new TreeBag([...this, ...other], null);
+		}
+		return new TreeBag([], [this, other]);
+	}
+
+	*[Symbol.iterator](): Iterator<T> {
+		yield* this.list;
+		if (this.children !== null) {
+			for (const child of this.children) {
+				yield* child;
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR is a refactor PR. It simplifies the logic, and also makes it much faster, by removing unnecessary calls to the very expensive method `EGraph.getClasses`.

This is accomplished by introducing a new "tag" which tracks the uses of functions in each EGraph component. This allows only relevant objects to be checked, sometimes giving significant savings. This PR also eliminates the redundant `EMatcher` class.