### PR TITLE
Eliminate `EGraph.getClasses` method

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
 		"cmd": "node --enable-source-maps built/shiru/cmd.js",
 		"build": "tsc",
 		"pack-es6": "tsc --project tsconfig-es6.json",
+		"prepack-es6": "node -e \" require('node:fs').rmSync('dist/shiru-es6', {recursive: true, force: true}); \"",
 		"test-satchecker": "node --enable-source-maps built/shiru/satchecker/checker.js"
 	},
 	"dependencies": {

--- a/src/shiru/data.ts
+++ b/src/shiru/data.ts
@@ -1,3 +1,7 @@
+type Tail<T extends readonly unknown[]> = T extends [unknown, ... infer Tail]
+	? Tail
+	: never;
+
 /**
  * TrieMap implements a map where keys are arrays (or tuples).
  * This is implemented using a "trie" of ES6 Map objects.
@@ -6,6 +10,17 @@ export class TrieMap<KS extends readonly unknown[], V> {
 	private map: Map<KS[number], TrieMap<KS, V>> = new Map();
 	private value: V | undefined = undefined;
 	size: number = 0;
+
+	/**
+	 * Note that the returned map should NOT be mutated.
+	 */
+	getSuffixes(key: KS[0]): TrieMap<Tail<KS>, V> | undefined {
+		const at = this.map.get(key);
+		if (at === undefined) {
+			return undefined;
+		}
+		return at as unknown as TrieMap<Tail<KS>, V>;
+	}
 
 	get(key: KS, from: number = 0): V | undefined {
 		let cursor: TrieMap<KS, V> | undefined = this;

--- a/src/shiru/egraph.ts
+++ b/src/shiru/egraph.ts
@@ -367,22 +367,15 @@ export class EGraph<Term, TagValues extends Record<string, unknown>, Reason> {
 		return this.components.representative(obj);
 	}
 
-	getClasses(duplicate?: boolean): Map<EObject, EClassDescription<Term>> {
-		const mapping: Map<EObject, EClassDescription<Term>> = new Map();
-		for (const [k, id] of this.tuples) {
-			const representative = this.components.representative(id);
-			let eclass = mapping.get(representative);
-			if (eclass === undefined) {
-				eclass = { members: [], representative };
-				mapping.set(representative, eclass);
-			}
-			if (duplicate) {
-				mapping.set(id, eclass);
-			}
-			const term = k[0];
-			const operands = k.slice(1) as EObject[];
-			eclass.members.push({ id, term, operands });
+	getAllApplications(fn: Term): { id: EObject, operands: EObject[] }[] {
+		const applications = this.tuples.getSuffixes(fn);
+		const out: { id: EObject, operands: EObject[] }[] = [];
+		if (applications === undefined) {
+			return out;
 		}
-		return mapping;
+		for (const [operands, id] of applications) {
+			out.push({ id, operands: operands.slice(0) });
+		}
+		return out;
 	}
 }

--- a/src/shiru/egraph_tests.ts
+++ b/src/shiru/egraph_tests.ts
@@ -129,17 +129,13 @@ export const tests = {
 			let madeChange = true;
 			while (madeChange) {
 				madeChange = false;
-				for (const [eclass, { members }] of eg.getClasses()) {
-					for (const member of members) {
-						if (member.term === "+") {
-							const cs = getTags(eg, "constant", member.operands);
-							if (cs !== null) {
-								const sum = cs.values[0].number + cs.values[1].number;
-								const sumObject = eg.add(sum, []);
-								eg.addTag(sumObject, "constant", { id: sumObject, number: sum });
-								madeChange = eg.mergeApplications(sumObject, member.id, cs.reasons, [], []) || madeChange;
-							}
-						}
+				for (const member of eg.getAllApplications("+")) {
+					const cs = getTags(eg, "constant", member.operands);
+					if (cs !== null) {
+						const sum = cs.values[0].number + cs.values[1].number;
+						const sumObject = eg.add(sum, []);
+						eg.addTag(sumObject, "constant", { id: sumObject, number: sum });
+						madeChange = eg.mergeApplications(sumObject, member.id, cs.reasons, [], []) || madeChange;
 					}
 				}
 

--- a/src/shiru/smt.ts
+++ b/src/shiru/smt.ts
@@ -171,6 +171,7 @@ export abstract class SMTSolver<E, Counterexample> {
 		// Use the SMT solver's clauses, rather than the SAT solver's clauses,
 		// to exclude any learned CDCL clauses.
 		const simplified = solver.simplifyClauses([...this.clauses, ...this.unscopedClauses]);
+		const simplifyingAssignment = new Set(solver.getAssignment());
 
 		trace.mark("Result of partial solving", () => {
 			const lines = this.showFormula(simplified);
@@ -236,7 +237,9 @@ export abstract class SMTSolver<E, Counterexample> {
 					// this.
 					solver.rollbackToDecisionLevel(-1);
 					if (theoryClauses.length === 0) {
-						throw new Error("SMTSolver.attemptRefutation: expected at least one clause from theory refutation");
+						throw new Error(
+							"SMTSolver.attemptRefutation: expected at least one clause from theory refutation"
+						);
 					}
 
 					trace.start(["learned ", theoryClauses.length, " theory clauses"]);
@@ -248,6 +251,11 @@ export abstract class SMTSolver<E, Counterexample> {
 						trace.mark(["learned clause of", theoryClause.length, "terms"], () => {
 							const lines: string[] = [];
 							this.showClause(theoryClause, new Set(), lines);
+							return lines.join("\n");
+						});
+						trace.mark("simplified version", () => {
+							const lines: string[] = [];
+							this.showClause(theoryClause, simplifyingAssignment, lines);
 							return lines.join("\n");
 						});
 

--- a/src/shiru/trace.ts
+++ b/src/shiru/trace.ts
@@ -68,7 +68,7 @@ export class Stopwatch {
 	}
 }
 
-const stopwatch = new Stopwatch(performance.now);
+const stopwatch = new Stopwatch(() => performance.now());
 
 export function clear(title: string) {
 	root = {

--- a/src/shiru/uf.ts
+++ b/src/shiru/uf.ts
@@ -370,39 +370,14 @@ export class UFSolver<Reason> {
 			trace.stop();
 
 			if (this.pendingInconsistencies.length !== 0) {
-				trace.start("diagnose inconsistencies");
-				// Convert the inconsistencies to sets of incompatible reasons
-				// which can be understood by the SAT solver.
-				const reasonSets: Set<Reason>[] = [];
-				for (const inconsistency of this.pendingInconsistencies) {
-					const conjunction = new Set<Reason>();
-					const subConjunctions: Set<Reason>[] = [];
-					for (const equality of inconsistency.equalityConstraints) {
-						const subConjunction = this.egraph.explainCongruence(equality.left, equality.right);
-						subConjunctions.push(subConjunction);
-						for (const r of subConjunction) {
-							conjunction.add(r);
-						}
-					}
-					if (inconsistency.simpleReasons && inconsistency.simpleReasons.length !== 0) {
-						for (const simpleReason of inconsistency.simpleReasons) {
-							conjunction.add(simpleReason);
-						}
-					}
-					reasonSets.push(conjunction);
-					// Marks?
-					trace.mark("inconsistency " + conjunction.size, () => {
-						const out: string[] = [];
-						for (const equality of inconsistency.equalityConstraints) {
-							out.push(String(equality.left) + " =?= " + String(equality.right));
-							out.push(...[...subConjunctions.shift()!].map(x => String(x)));
-							out.push("");
-						}
-						return out.join("\n");
-					});
-				}
-				trace.stop("diagnose inconsistencies");
-				return { tag: "inconsistent", inconsistencies: reasonSets };
+				trace.start("diagnoseInconsistencies");
+				const inconsistencies = this.pendingInconsistencies
+					.map(x => this.diagnoseInconsistency(x));
+				trace.stop("diagnoseInconsistencies");
+				return {
+					tag: "inconsistent",
+					inconsistencies
+				};
 			}
 		}
 
@@ -424,6 +399,46 @@ export class UFSolver<Reason> {
 			model: { model: {} },
 			answers,
 		};
+	}
+
+	/**
+	 * Convert the set of theory constraints to a conjunction of `Reason`s which
+	 * are inconsistent in this theory.
+	 */
+	private diagnoseInconsistency(inconsistency: InconsistentConstraints<Reason>): Set<Reason> {
+		trace.mark([
+			"diagnoseInconsistency",
+			inconsistency.equalityConstraints.length,
+			"eqs",
+			inconsistency.simpleReasons,
+		], () => {
+			const lines: string[] = [];
+			const stringified = JSON.stringify(inconsistency, (_, value) => {
+				if (typeof value === "symbol") {
+					return String(value);
+				} else if (typeof value === "bigint") {
+					return String(value);
+				}
+				return value;
+			}, "\t");
+			lines.push(stringified);
+			return lines.join("\n");
+		});
+		const conjunction = new Set<Reason>();
+		const subConjunctions: Set<Reason>[] = [];
+		for (const equality of inconsistency.equalityConstraints) {
+			const subConjunction = this.egraph.explainCongruence(equality.left, equality.right);
+			subConjunctions.push(subConjunction);
+			for (const r of subConjunction) {
+				conjunction.add(r);
+			}
+		}
+		if (inconsistency.simpleReasons && inconsistency.simpleReasons.length !== 0) {
+			for (const simpleReason of inconsistency.simpleReasons) {
+				conjunction.add(simpleReason);
+			}
+		}
+		return conjunction;
 	}
 
 	private handleTrueMembers(): boolean {


### PR DESCRIPTION
This PR eliminates the expensive `EGraph.getClasses`, in favor of a more efficient and more convenient `EGraph.getAllApplications` method.

This gives a noticeable performance improvement:

* [current main](https://github.com/CurtisFenner/shiru-ts/actions/runs/4707233861/jobs/8348985363)
    * ```
      Slowest: verify_tests.duplicated-assert-is-fast took 3468 ms
      Done in 6.03s.
        ```
* [this commit](https://github.com/CurtisFenner/shiru-ts/actions/runs/4821745082/jobs/8588037108)
    * ```
      Slowest: verify_tests.duplicated-assert-is-fast took 2672 ms
      Done in 4.94s.
      ```