### PR TITLE
Perf improvements: Reduce amount of theory solving

### DIFF
--- a/src/shiru/data.ts
+++ b/src/shiru/data.ts
@@ -257,3 +257,13 @@ export function* zipMaps<K, A, B>(
 		}
 	}
 }
+
+export function measureCommonPrefix<T>(a: T[], b: T[]): number {
+	const length = Math.min(a.length, b.length);
+	for (let i = 0; i < length; i++) {
+		if (a[i] !== b[i]) {
+			return i;
+		}
+	}
+	return length;
+}

--- a/src/shiru/smt.ts
+++ b/src/shiru/smt.ts
@@ -149,17 +149,17 @@ export abstract class SMTSolver<E, Counterexample> {
 					unassigned.push(term);
 				}
 			}
-			const additional = this.learnAdditional(partialAssignment, unassigned);
-			if (additional === "unsatisfiable") {
+			const additionalClauses = this.learnAdditional(partialAssignment, unassigned);
+			if (additionalClauses === "unsatisfiable") {
 				trace.stop("partial-theory-simplification");
 				return "refuted";
-			} else if (additional.length === 0) {
-				// No unit clauses were added.
+			} else if (additionalClauses.length === 0) {
+				// No clauses were learned.
 				break;
 			}
-			for (const literal of additional) {
-				// Add additional unit clauses that are implied by the theory.
-				solver.addClause([literal]);
+			for (const clause of additionalClauses) {
+				// Add additional clauses that are implied by the theory.
+				solver.addClause(clause);
 			}
 		}
 		trace.stop("partial-theory-simplification");
@@ -312,7 +312,7 @@ export abstract class SMTSolver<E, Counterexample> {
 	protected abstract learnAdditional(
 		partialAssignment: sat.Literal[],
 		unassigned: sat.Literal[],
-	): sat.Literal[] | "unsatisfiable";
+	): sat.Literal[][] | "unsatisfiable";
 
 	/// clausify returns a set of clauses to add to the underlying SAT solver.
 	/// This modifies state, associating literals (and other internal variables)

--- a/src/shiru/smt.ts
+++ b/src/shiru/smt.ts
@@ -1,5 +1,6 @@
-import * as trace from "./trace.js";
+import * as data from "./data.js";
 import * as sat from "./sat.js";
+import * as trace from "./trace.js";
 
 /// SMTSolver represents an "satisfiability modulo theories" instance, with
 /// support for quantifier instantiation.
@@ -206,72 +207,90 @@ export abstract class SMTSolver<E, Counterexample> {
 		});
 
 		trace.start("solving");
+		let lastUndeterminedBooleanModel: sat.Literal[] = [];
 		while (true) {
 			const booleanModel = solver.solve();
 			if (booleanModel === "unsatisfiable") {
 				trace.stop("solving");
 				return "refuted";
-			} else {
-				// Clausal proof adds additional constraints to the formula, which
-				// preserve satisfiablity (but not necessarily logical equivalence).
-				// These are useful in subsequent runs of the solver; HOWEVER,
-				// clauses which merely preserve satisfiability and not logical
-				// equivalence must be pruned.
-				// TODO: Remove (and attempt to re-add) any non-implied clauses.
-				const restrictedBooleanModel = booleanModel.filter(literal => {
-					const term = literal > 0 ? +literal : -literal;
-					return instantiationTerms.has(term) || termsRequiringAssignment.has(term);
-				});
-				trace.start("rejectBooleanModel");
-				trace.mark(["booleanModel (not passed to theory) size:", booleanModel.length], () => {
-					return booleanModel.map(x => this.showLiteral(x)).join("\n");
-				});
-				trace.mark(["restrictedBooleanModel size:", restrictedBooleanModel.length], () => {
-					return restrictedBooleanModel.map(x => this.showLiteral(x)).join("\n");
-				});
-				const theoryClauses = this.rejectBooleanModel(restrictedBooleanModel);
-				if (Array.isArray(theoryClauses)) {
-					// Completely undo the assignment.
-					// TODO: theoryClauses should contain an asserting clause,
-					// so the logic in backtracking should be able to replace
-					// this.
-					solver.rollbackToDecisionLevel(-1);
-					if (theoryClauses.length === 0) {
-						throw new Error(
-							"SMTSolver.attemptRefutation: expected at least one clause from theory refutation"
-						);
-					}
-
-					trace.start(["learned ", theoryClauses.length, " theory clauses"]);
-					for (const theoryClause of theoryClauses) {
-						if (theoryClause.length === 0) {
-							throw new Error("SMTSolver.attemptRefutation: expected theoryClause to not be empty");
-						}
-
-						trace.mark(["learned clause of", theoryClause.length, "terms"], () => {
-							const lines: string[] = [];
-							this.showClause(theoryClause, new Set(), lines);
-							return lines.join("\n");
-						});
-						trace.mark("simplified version", () => {
-							const lines: string[] = [];
-							this.showClause(theoryClause, simplifyingAssignment, lines);
-							return lines.join("\n");
-						});
-
-						solver.addClause(theoryClause);
-					}
-					trace.stop();
-					trace.stop();
-				} else {
-					trace.stop();
-					// TODO: Instantiation may need to take place here.
-					// The SAT+SMT solver has failed to refute the formula.
-					solver.rollbackToDecisionLevel(-1);
-					trace.stop("solving");
-					return theoryClauses;
-				}
 			}
+
+			const instantiationBooleanModel = booleanModel.filter(literal => {
+				const term = literal > 0 ? +literal : -literal;
+				return instantiationTerms.has(term);
+			});
+			const undeterminedBooleanModel = booleanModel.filter(literal => {
+				const term = literal > 0 ? +literal : -literal;
+				return termsRequiringAssignment.has(term);
+			});
+			trace.start("rejectBooleanModel");
+			trace.mark([
+				"booleanModel (not passed to theory) size:",
+				booleanModel.length,
+				"=",
+				instantiationBooleanModel.length,
+				"instantiation",
+				"+",
+				undeterminedBooleanModel.length,
+				"undetermined",
+			], () => {
+				return booleanModel.map(x => this.showLiteral(x)).join("\n");
+			});
+
+			const commonWithLast = data.measureCommonPrefix(lastUndeterminedBooleanModel, undeterminedBooleanModel);
+			lastUndeterminedBooleanModel = undeterminedBooleanModel.slice(0);
+			const notCommon = lastUndeterminedBooleanModel.length - commonWithLast;
+			const partialModel = commonWithLast + notCommon / 1.5;
+
+			// Attempt to reject using a smaller boolean model
+			const smallerTheoryClauses = this.rejectBooleanModel((undeterminedBooleanModel.slice(0, partialModel)));
+
+			const theoryClauses = Array.isArray(smallerTheoryClauses)
+				? smallerTheoryClauses
+				: this.rejectBooleanModel(instantiationBooleanModel.concat(undeterminedBooleanModel));
+
+			if (Array.isArray(theoryClauses)) {
+				// Completely undo the assignment.
+				// TODO: theoryClauses should contain an asserting clause,
+				// so the logic in backtracking should be able to replace
+				// this.
+				solver.rollbackToDecisionLevel(-1);
+				if (theoryClauses.length === 0) {
+					throw new Error(
+						"SMTSolver.attemptRefutation: expected at least one clause from theory refutation"
+					);
+				}
+
+				trace.start(["learned ", theoryClauses.length, " theory clauses"]);
+				for (const theoryClause of theoryClauses) {
+					if (theoryClause.length === 0) {
+						throw new Error("SMTSolver.attemptRefutation: expected theoryClause to not be empty");
+					}
+
+					trace.mark(["learned clause of", theoryClause.length, "terms"], () => {
+						const lines: string[] = [];
+						this.showClause(theoryClause, new Set(), lines);
+						return lines.join("\n");
+					});
+					trace.mark("simplified version", () => {
+						const lines: string[] = [];
+						this.showClause(theoryClause, simplifyingAssignment, lines);
+						return lines.join("\n");
+					});
+
+					solver.addClause(theoryClause);
+				}
+				trace.stop();
+				trace.stop();
+			} else {
+				trace.stop();
+				// TODO: Instantiation may need to take place here.
+				// The SAT+SMT solver has failed to refute the formula.
+				solver.rollbackToDecisionLevel(-1);
+				trace.stop("solving");
+				return theoryClauses;
+			}
+
 		}
 	}
 

--- a/src/shiru/smt_tests.ts
+++ b/src/shiru/smt_tests.ts
@@ -49,7 +49,7 @@ class BoundedTheory extends SMTSolver<BoundedRelation[], Record<string, number>>
 	protected learnAdditional(
 		partialAssignment: number[],
 		unassigned: number[],
-	): number[] | "unsatisfiable" {
+	): number[][] | "unsatisfiable" {
 		return [];
 	}
 

--- a/src/shiru/trace.ts
+++ b/src/shiru/trace.ts
@@ -178,7 +178,8 @@ export function renderTree(stack: Trace, out: string[], settings: { open: boolea
 		out.push("<summary>");
 		out.push("<div class=perf-spark>");
 		const totalPercentage = 100 * getDurationMs(stack) / settings.totalTimeMs;
-		out.push(`<div class=bar style="width: ${totalPercentage.toFixed(2)}%"></div>`);
+		const startPercentage = 100 * stack.start / settings.totalTimeMs;
+		out.push(`<div class=bar style="left: ${startPercentage.toFixed(2)}%; width: ${totalPercentage.toFixed(2)}%"></div>`);
 		out.push("</div>");
 		const durationText = stack.end ? getDurationMs(stack).toFixed(1) : "?";
 		out.push("<span class=numeral>" + durationText + " ms</span> &mdash; ");

--- a/src/shiru/uf.ts
+++ b/src/shiru/uf.ts
@@ -446,23 +446,24 @@ export class UFSolver<Reason> {
 		const trueApplications = this.egraph.getTagged("indexByFn", this.trueObject);
 		if (trueApplications !== null) {
 			for (const [fn, applications] of trueApplications) {
+				trace.start([String(fn), "has", applications.size, "applications"]);
 				const fnDefinition = this.fns.get(fn)!;
 				if (fnDefinition.semantics.eq === true) {
 					for (const application of applications) {
-						const changeMade = this.handleTrueEquality(
-							application.id,
-							application.operands as [ValueID, ValueID],
+						const changeMade = this.egraph.mergeApplications(
+							application.operands[0],
+							application.operands[1],
+							null,
+							[application.id],
+							[this.trueObject],
 						);
 						progress = progress || changeMade;
 					}
 				}
+				trace.stop();
 			}
 		}
 		return progress;
-	}
-
-	private handleTrueEquality(equality: ValueID, [left, right]: [ValueID, ValueID]): boolean {
-		return this.egraph.mergeApplications(left, right, null, [equality], [this.trueObject]);
 	}
 
 	private handleFalseMembers(): boolean {


### PR DESCRIPTION
This PR significantly improves the performance of the SMT solver with two main changes:

* Before doing full theory solving, a subset of the model is attempted, to more quickly get theory clauses
* Equalities of booleans are clausified for the SAT solver so that the theory solver won't spend time refuting them

We can see a noticeable improvement in the GitHub CI times:

* current `main`: https://github.com/CurtisFenner/shiru-ts/actions/runs/4821794438/jobs/8588156874
    > Slowest: verify_tests.duplicated-assert-is-fast took 2772 ms
    > Done in 4.96s.
* this PR: https://github.com/CurtisFenner/shiru-ts/actions/runs/4842439831/jobs/8629394094?pr=9
    > Slowest: verify_tests.duplicated-assert-is-fast took 1776 ms
    > Done in 4.19s.
    * Slowest has -36% runtime
    * Overall has -15% runtime