### PR TITLE
Add additional verification interpreters and fix import

### DIFF
--- a/src/shiru/builtin.ts
+++ b/src/shiru/builtin.ts
@@ -123,7 +123,9 @@ export const foreignOperations: Record<string, {
 					location: ir.NONE,
 				},
 			],
-			semantics: {},
+			semantics: {
+				not: true,
+			},
 		},
 	},
 	// Integer less-than function.

--- a/src/shiru/builtin.ts
+++ b/src/shiru/builtin.ts
@@ -372,6 +372,21 @@ export const foreignOperations: Record<string, {
 			semantics: {
 				transitive: true,
 			},
+
+		},
+		getInterpreter(foreignFns) {
+			return {
+				interpreter(a: unknown | null, b: unknown | null): unknown | null {
+					if (a === null || b === null) {
+						return null;
+					} else if (typeof a !== "bigint") {
+						return null;
+					} else if (typeof b !== "bigint") {
+						return null;
+					}
+					return (a as bigint) <= (b as bigint);
+				},
+			}
 		},
 	},
 	// Integer addition function.
@@ -641,6 +656,21 @@ export const foreignOperations: Record<string, {
 					location: ir.NONE,
 				},
 			],
+		},
+		getInterpreter(foreignFns) {
+			return {
+				interpreter(a: unknown | null, b: unknown | null): unknown | null {
+					if (a === null || b === null) {
+						return null;
+					} else if (typeof a !== "bigint") {
+						return null;
+					} else if (typeof b !== "bigint") {
+						return null;
+					}
+
+					return (a as bigint) - (b as bigint);
+				},
+			};
 		},
 	},
 	// Integer additive inverse function.

--- a/src/shiru/cmd.ts
+++ b/src/shiru/cmd.ts
@@ -1,5 +1,5 @@
 import * as fs from "fs";
-import path = require("path");
+import * as path from "path";
 import * as process from "process";
 import { codegenJs } from "./codegen_js.js";
 import * as diagnostics from "./diagnostics.js";

--- a/src/shiru/ir.ts
+++ b/src/shiru/ir.ts
@@ -434,6 +434,13 @@ export interface FunctionSignature {
 		/// admit cycles (a < b < c < d < ... < a). This implies that the relation
 		/// is anti-reflexive.
 		transitiveAcyclic?: true,
+
+		/**
+		 * Indicates that this has the definition
+		 * f(true) == false
+		 * f(false) == true
+		 */
+		not?: true,
 	},
 };
 

--- a/src/shiru/uf.ts
+++ b/src/shiru/uf.ts
@@ -848,7 +848,17 @@ export class UFTheory extends smt.SMTSolver<ValueID[], UFCounterexample> {
 			if (symmetric !== null) {
 				return symmetric;
 			}
+		} else if (semantics.not) {
+			const operand = args[0];
+			const operandDefinition = this.solver.getDefinition(operand);
+			if (operandDefinition.tag === "application") {
+				const semantics = this.solver.getFnSemantics(operandDefinition.fn);
+				if (semantics.not === true) {
+					return operandDefinition.operands[0];
+				}
+			}
 		}
+
 		return this.solver.createApplication(fnID, args);
 	}
 

--- a/src/shiru/verify.ts
+++ b/src/shiru/verify.ts
@@ -915,6 +915,7 @@ class VerificationState {
 				generalInterpreter: interpreters?.generalInterpreter,
 				transitive: signature.semantics?.transitive,
 				transitiveAcyclic: signature.semantics?.transitiveAcyclic,
+				not: signature.semantics?.not,
 			}, op));
 		}
 		return out;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ES2020",
-    "moduleResolution": "node16",
     "outDir": "built",
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
This PR adds additional interpreters for several builtins, exposes a `not` semantics property to be applied to `Boolean.not`, and also fixes an issue with a `require` used instead of an `import`.