### PR TITLE
Implement faster, less complete constraint solver

### DIFF
--- a/src/shiru/components_tests.ts
+++ b/src/shiru/components_tests.ts
@@ -3,7 +3,7 @@ import { assert, specPredicate, specSetEq } from "./test.js";
 
 export const tests = {
 	"simple-search"() {
-		const cs = new Components<string, number>();
+		const cs = new Components<string, number, number>(() => 1, (a, b) => a + b);
 		const addAB = cs.addCongruence("alpha", "beta", 100, []);
 		const addBG = cs.addCongruence("beta", "gamma", 200, []);
 		const addGD = cs.addCongruence("delta", "gamma", 300, []);
@@ -32,7 +32,7 @@ export const tests = {
 		assert(cs.findPathAtTime({ left: "alpha", right: "beta" }, addGD), "is equal to", null);
 	},
 	"simple-dependencies"() {
-		const cs = new Components<string, number>();
+		const cs = new Components<string, number, number>(() => 1, (a, b) => a + b);
 		const addAB = cs.addCongruence("a", "b", 100, []);
 		assert(cs.areCongruent("f(a)", "f(b)"), "is equal to", false);
 		const addFAFB = cs.addCongruence("f(a)", "f(b)", 200, [{ left: "a", right: "b" }]);

--- a/src/shiru/data_tests.ts
+++ b/src/shiru/data_tests.ts
@@ -1,7 +1,16 @@
-import { TrieMap, DisjointSet } from "./data.js";
+import { leastSignificantBit, TrieMap, DisjointSet } from "./data.js";
 import { assert } from "./test.js";
 
 export const tests = {
+	"leastSignificantBit"() {
+		// Ensure this doesn't hang.
+		// The resulting value is indeterminate.
+		leastSignificantBit(0n);
+
+		assert(leastSignificantBit(1n), "is equal to", 0);
+		assert(leastSignificantBit(1n << 5001n), "is equal to", 5001);
+		assert(leastSignificantBit((1n << 12345n) + (1n << 34567n)), "is equal to", 12345);
+	},
 	"TrieMap-basic"() {
 		const map: TrieMap<number[], string> = new TrieMap();
 
@@ -46,7 +55,7 @@ export const tests = {
 		]);
 	},
 	"DisjointSet-basic"() {
-		const ds = new DisjointSet();
+		const ds = new DisjointSet(() => 1, (a, b) => a + b);
 		assert(ds.compareEqual(0, 0), "is equal to", true);
 		assert(ds.representative(0), "is equal to", 0);
 		assert(ds.compareEqual(1, 2), "is equal to", false);
@@ -73,7 +82,7 @@ export const tests = {
 		]);
 	},
 	"DisjointSet-basic-explainEquality"() {
-		const ds = new DisjointSet();
+		const ds = new DisjointSet(() => 1, (a, b) => a + b);
 		ds.union(0, 1);
 		ds.union(5, 4);
 		ds.union(1, 2);
@@ -85,7 +94,7 @@ export const tests = {
 		assert(ds.compareEqual(1, 1), "is equal to", true);
 	},
 	"DisjointSet-explainEquality-efficient"() {
-		const ds = new DisjointSet();
+		const ds = new DisjointSet(() => 1, (a, b) => a + b);
 
 		const count = 1000;
 		for (let i = 0; i < count; i++) {

--- a/src/shiru/egraph.ts
+++ b/src/shiru/egraph.ts
@@ -134,7 +134,7 @@ export class EGraph<Term, TagValues extends Record<string, unknown>, Reason> {
 		EObject,
 		{ term: Term, operands: EObject[], uniqueObjectCount: number, extra: unknown }
 	> = new Map();
-	private components = new Components<EObject, Reason>();
+	private components = new Components<EObject, Reason, null>(() => null, () => null);
 
 	private lazyCongruence: PendingCongruence[] = [];
 

--- a/src/shiru/uf_tests.ts
+++ b/src/shiru/uf_tests.ts
@@ -793,4 +793,34 @@ export const tests = {
 		assert(response4, "is equal to", "refuted");
 		smt.popScope();
 	},
+	"UFTheory-basic-fastRefuteUsingTheory"() {
+		const solver = new uf.UFSolver();
+		const predicateA = solver.createVariable(ir.T_BOOLEAN, "predicateA");
+		const predicateB = solver.createVariable(ir.T_BOOLEAN, "predicateB");
+		const predicateC = solver.createVariable(ir.T_BOOLEAN, "predicateC");
+
+		const varB = solver.createVariable(ir.T_INT, "varB");
+		const varC = solver.createVariable(ir.T_INT, "varC");
+		const zero = solver.createConstant(0n);
+
+		const fEq = solver.createFn(ir.T_BOOLEAN, { eq: true }, "==");
+		const fLt = solver.createFn(ir.T_BOOLEAN, { transitive: true, transitiveAcyclic: true }, "<");
+		const fLeq = solver.createFn(ir.T_BOOLEAN, { transitive: true }, "<=");
+		const fPlus = solver.createFn(ir.T_INT, {}, "+");
+		const eq = (a: uf.ValueID, b: uf.ValueID) => solver.createApplication(fEq, [a, b]);
+		const leq = (a: uf.ValueID, b: uf.ValueID) => solver.createApplication(fLeq, [a, b]);
+		const lt = (a: uf.ValueID, b: uf.ValueID) => solver.createApplication(fLt, [a, b]);
+		const plus = (a: uf.ValueID, b: uf.ValueID) => solver.createApplication(fPlus, [a, b]);
+
+		solver.fastRefuteUsingTheory([
+			{ constraint: eq(predicateA, leq(zero, varB)), assignment: true, reason: 1 },
+			{ constraint: eq(varB, zero), assignment: true, reason: 2, },
+			{ constraint: eq(predicateA, eq(varB, zero)), assignment: true, reason: 3 },
+			{ constraint: eq(predicateB, lt(zero, plus(varB, varC))), assignment: true, reason: 4 },
+			{ constraint: eq(predicateC, lt(varB, plus(varB, varC))), assignment: false, reason: 5 },
+			{ constraint: eq(varB, plus(varB, varC)), assignment: true, reason: 6 },
+			{ constraint: eq(predicateC, eq(varB, plus(varB, varC))), assignment: true, reason: 7 },
+			{ constraint: eq(predicateB, leq(zero, plus(varB, varC))), assignment: true, reason: 8 },
+		]);
+	},
 };


### PR DESCRIPTION
This PR introduces a new `FastSolver` class which implements a simplified, faster but less complete solver for the UF theory.

In addition, it augments the `Components` and `DisjointSet` data structures with extra information to be stored in each component.

This can modestly reduce runtime in the most expensive verifications (by about 10%), by skipping the slow solver when the fast solver can refute an instance.

> Passed: 203.
> Failed: 0.
> Slowest: verify_tests.duplicated-assert-is-fast took 1352 ms
> Done in 3.28s.

