### PR TITLE
Smarter branching

### DIFF
--- a/src/shiru/smt.ts
+++ b/src/shiru/smt.ts
@@ -187,7 +187,7 @@ export abstract class SMTSolver<E, Model> {
 			}
 		}
 
-		trace.mark("termsRequiringAssignment", () => {
+		trace.mark([termsRequiringAssignment.size, "termsRequiringAssignment"], () => {
 			const lines = [...termsRequiringAssignment].map(x => this.showLiteral(x));
 			return lines.join("\n");
 		});
@@ -199,7 +199,7 @@ export abstract class SMTSolver<E, Model> {
 			instantiationTerms.add(Math.abs(literal));
 		}
 
-		trace.mark("instantiationTerms", () => {
+		trace.mark([instantiationTerms.size, "instantiationTerms"], () => {
 			const lines = [...instantiationTerms].map(x => this.showLiteral(x));
 			return lines.join("\n");
 		});

--- a/src/shiru/trace.ts
+++ b/src/shiru/trace.ts
@@ -144,21 +144,11 @@ export function stopThreshold(thresholdMs: number, title?: string): void {
 }
 
 function showValue(x: unknown): [string, string] {
-	const s = JSON.stringify(x, (key, value) => {
-		if (typeof value === "bigint") {
-			return value.toString() + "n";
-		} else if (typeof value === "symbol") {
-			return String(value);
-		} else {
-			return value;
-		}
-	});
-
 	if (typeof x === "string") {
 		return [x, ""];
 	}
 
-	return ["", String(s)];
+	return ["", String(x)];
 }
 
 function limitPrecision(n: number | null): number | null {

--- a/src/shiru/uf.ts
+++ b/src/shiru/uf.ts
@@ -1309,15 +1309,19 @@ export class UFTheory extends smt.SMTSolver<ValueID[], UFCounterexample> {
 	createVariable(type: ir.Type, debugName: string): ValueID {
 		const v = this.solver.createVariable(type, debugName);
 		if (ir.equalTypes(ir.T_BOOLEAN, type)) {
-			// Boolean-typed variables must be equal to either true or false.
-			// This constraint ensures that the sat solver will commit the
-			// variable to a particular assignment.
-			this.addConstraint([
-				v,
-				this.createApplication(this.notFn, [v]),
-			]);
+			this.addBooleanBranchConstraint(v);
 		}
 		return v;
+	}
+
+	private addBooleanBranchConstraint(value: ValueID): void {
+		// Boolean-typed variables must be equal to either true or false.
+		// This constraint ensures that the sat solver will commit the
+		// variable to a particular assignment.
+		this.addConstraint([
+			value,
+			this.createApplication(this.notFn, [value]),
+		]);
 	}
 
 	createConstant(t: ir.Type, c: unknown): ValueID {


### PR DESCRIPTION
This PR simplifies and improves the use of the SMT solver.

The changes include:

* Simplifying the `pathConstraints` of the `VerificationState` to use only unit clauses. Previous multi-literal clauses are instead added using an inner SMT scope, rather than path-constraints.
* Raw use of `addConstraint` has been removed in favor of a new `addDisjunctionInPath` constraint. This helps to ensure soundness in the presence of branches which cannot be taken, which might have "side effects" adding contradictory clauses to the verification state.
* The clausification of the integer-bounding expression has been improved to be more accurate
* If-then-else "phi" variables are now cached, which means duplicated expressions which use `and` / `or` / `implies` should more often use the same SMT expressions, reducing the number of solve attempts that are needed.

These changes result in a modest performance improvement:

```
Passed: 203.
Failed: 0.
Slowest: verify_tests.duplicated-assert-is-fast took 713 ms
Done in 2.34s.
```

<details>
<summary>For reference, the current `main` (d2e18f3) build result</summary>

```
Passed: 203.
Failed: 0.
Slowest: verify_tests.duplicated-assert-is-fast took 1142 ms
Done in 2.88s.
```
</details>
